### PR TITLE
Fix missing fan unload

### DIFF
--- a/custom_components/comfoclime/__init__.py
+++ b/custom_components/comfoclime/__init__.py
@@ -88,6 +88,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_unload(entry, "switch")
     await hass.config_entries.async_forward_entry_unload(entry, "number")
     await hass.config_entries.async_forward_entry_unload(entry, "select")
+    await hass.config_entries.async_forward_entry_unload(entry, "fan")
     hass.data[DOMAIN].pop(entry.entry_id)
     return True
 


### PR DESCRIPTION
## Summary
- ensure the fan platform is unloaded on entry removal

## Testing
- `python3 -m py_compile custom_components/comfoclime/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684c62f753cc8320b6d7b3f167f8b37b